### PR TITLE
Language changes

### DIFF
--- a/ThePorch/src/AboutCampus/index.js
+++ b/ThePorch/src/AboutCampus/index.js
@@ -81,7 +81,7 @@ const AboutCampus = ({ navigation }) => {
                       {/* fixes text/navigation spacing by adding vertical padding if we dont have an image */}
                       <PaddedView>
                         <Header>
-                          <StyledH6>{'My Campus'}</StyledH6>
+                          <StyledH6>{'Your Porch Location'}</StyledH6>
                           <H2>{name}</H2>
                         </Header>
                       </PaddedView>

--- a/ThePorch/src/tabs/connect/Connect.js
+++ b/ThePorch/src/tabs/connect/Connect.js
@@ -52,16 +52,16 @@ class Connect extends PureComponent {
                 {({ userCampus }) =>
                   userCampus ? (
                     <CurrentCampus
-                      cardButtonText={'Campus Details'}
+                      cardButtonText={'Location Details'}
                       cardTitle={userCampus.name}
                       coverImage={userCampus.image}
-                      headerActionText={'Change'}
+                      headerActionText={'Change Location'}
                       headerBackgroundColor={screenProps.headerBackgroundColor}
                       headerTintColor={screenProps.headerTintColor}
                       headerTitleColor={screenProps.headerTitleStyle.color}
                       itemId={userCampus.id}
                       navigation={navigation}
-                      sectionTitle={'Your Campus'}
+                      sectionTitle={'Your Porch Location'}
                     />
                   ) : null
                 }

--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -181,7 +181,7 @@ HOME_FEATURES:
           limit: 1
     type: VerticalCardList
     isFeatured: true
-  - subtitle: Your Campus
+  - subtitle: Your Porch Location
     algorithms: [CAMPUS_ITEMS]
     type: ActionList
   - algorithms:

--- a/apollos-church-api/src/data/wcc-features/index.js
+++ b/apollos-church-api/src/data/wcc-features/index.js
@@ -47,7 +47,7 @@ class WCCFeatures extends baseFeatures.dataSource {
   });
 
   createWebviewFeature = ({ id, external_playlist }) => ({
-    title: 'Setlist',
+    title: 'Worship Set',
     // linkText: 'Open in Spotify',
     url: getSpotifyEmbed(external_playlist),
     id: createGlobalId(id, 'WebviewFeature'),


### PR DESCRIPTION
This PR updates the language from 'Campus' to 'Location' and from 'Setlist' to 'Worship Set'.

|iOS|Android|
|---|---|
|![Screen Shot 2020-05-28 at 3 39 13 PM](https://user-images.githubusercontent.com/52924611/83186281-49e16d80-a0fa-11ea-955c-4bce87a0741d.png)|<img width="397" alt="Screen Shot 2020-05-28 at 4 00 16 PM" src="https://user-images.githubusercontent.com/52924611/83187773-b0678b00-a0fc-11ea-974f-787a64b04847.png">|
|![Screen Shot 2020-05-28 at 3 39 23 PM](https://user-images.githubusercontent.com/52924611/83186360-6c738680-a0fa-11ea-8fa7-ee394520c0bc.png)|<img width="401" alt="Screen Shot 2020-05-28 at 4 00 28 PM" src="https://user-images.githubusercontent.com/52924611/83187810-beb5a700-a0fc-11ea-86e3-360fa3076751.png">|
|![Screen Shot 2020-05-28 at 3 39 33 PM](https://user-images.githubusercontent.com/52924611/83186436-82814700-a0fa-11ea-89f0-d1bc7d7796ee.png)|<img width="398" alt="Screen Shot 2020-05-28 at 4 00 38 PM" src="https://user-images.githubusercontent.com/52924611/83187835-caa16900-a0fc-11ea-8f89-64b2e21064ac.png">|
|![Screen Shot 2020-05-28 at 3 39 53 PM](https://user-images.githubusercontent.com/52924611/83186471-8ad98200-a0fa-11ea-85e4-d98fcac1bd18.png)|<img width="404" alt="Screen Shot 2020-05-28 at 4 00 58 PM" src="https://user-images.githubusercontent.com/52924611/83187857-d5f49480-a0fc-11ea-97e5-771642cccb24.png">|