### PR TITLE
Fix content feed border issue

### DIFF
--- a/ThePorch/src/content-feed/index.js
+++ b/ThePorch/src/content-feed/index.js
@@ -21,7 +21,11 @@ class ContentFeed extends PureComponent {
     const itemTitle = navigation.getParam('itemTitle', 'Content Channel');
     return {
       title: itemTitle,
-      headerStyle: { backgroundColor: screenProps.headerBackgroundColor },
+      headerStyle: {
+        backgroundColor: screenProps.headerBackgroundColor,
+        borderBottomWidth: 0,
+        elevation: 0,
+      },
     };
   };
 

--- a/ThePorch/src/tabs/discover/Discover.js
+++ b/ThePorch/src/tabs/discover/Discover.js
@@ -8,7 +8,13 @@ class Discover extends PureComponent {
   }
 }
 
-Discover.navigationOptions = {
+Discover.navigationOptions = (props) => ({
   header: null,
-};
+  headerStyle: {
+    backgroundColor: props.screenProps.headerBackgroundColor,
+    borderBottomWidth: 0,
+    elevation: 0,
+  },
+});
+
 export default Discover;


### PR DESCRIPTION
Fixes an issue with a white border showing up on the content feed header.
![image](https://user-images.githubusercontent.com/2528817/83684476-b225c880-a5ac-11ea-819a-c0fa73ceec4b.png)
