### PR TITLE
Data loading

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -46,7 +46,8 @@ export class dataSource extends ContentItem.dataSource {
       return upperFirst(camelCase(contentfulType));
     }
     if (typeof node.messages_count === 'number') return 'WCCSeries';
-    if (typeof node.id === 'number' || !isNaN(node.objectID))
+
+    if (typeof node.id === 'number' || !isNaN(Number(node.objectID)))
       return 'WCCMessage';
     return 'WCCBlog';
   };

--- a/apollos-church-api/src/data/WCCMediaAPIDataSource.js
+++ b/apollos-church-api/src/data/WCCMediaAPIDataSource.js
@@ -19,7 +19,6 @@ class dataSource extends RESTDataSource {
   };
 
   async getFromId(id) {
-    console.log('getFromID', id);
     const result = await this.get(id);
     if (
       !result ||

--- a/apollos-church-api/src/data/WCCMediaAPIDataSource.js
+++ b/apollos-church-api/src/data/WCCMediaAPIDataSource.js
@@ -13,10 +13,13 @@ class dataSource extends RESTDataSource {
   }`;
 
   willSendRequest = (request) => {
-    request.params.set('target', 'the_porch');
+    // TODO: really, this should be set on all requests.
+    // But for now, we're just going to set it manulaly on pagination requests
+    // request.params.set('target', 'the_porch');
   };
 
   async getFromId(id) {
+    console.log('getFromID', id);
     const result = await this.get(id);
     if (
       !result ||
@@ -78,6 +81,7 @@ class dataSource extends RESTDataSource {
       node,
       cursor: createCursor({
         ...paginationPartsForCursors,
+        target: 'the_porch', // todo
         offset: paginationPartsForCursors.offset + i + 1,
       }),
     }));


### PR DESCRIPTION
Fixes blog articles being identified as blog articles

Fixes the errors seen when tapping on content in the topics sections on the discover screen. This might be a temporary fix - the real issue is we're getting items from algolia indexes that aren't published on the right publishing target in their CMS. The problem is that I think this issue is subject to human error in the future, so I've removed including the_porch target just on `id` lookups, which might be a temporary fix or might be long term. Need to get confirmation from their team on this.