### PR TITLE
Android-font

### DIFF
--- a/ThePorch/src/theme/fontStack/index.android.js
+++ b/ThePorch/src/theme/fontStack/index.android.js
@@ -14,7 +14,7 @@ const fontStack = {
     bebas: { default: 'BebasNeue-Regular' },
   },
   ui: {
-    regular: 'sans-serif',
+    regular: 'System',
   },
 };
 

--- a/ThePorch/src/theme/theme.js
+++ b/ThePorch/src/theme/theme.js
@@ -113,29 +113,21 @@ const overrides = {
   },
   H2: {
     fontFamily: typography.sans.bebas.default,
-    fontWeight: '700',
-    fontSize: 54,
-    lineHeight: 54,
   },
   H3: {
     fontFamily: typography.sans.regular.default,
-    fontWeight: '600',
   },
   H4: {
     fontFamily: typography.sans.regular.default,
-    fontWeight: '600',
   },
   H5: {
     fontFamily: typography.sans.regular.default,
-    fontWeight: '600',
   },
   H6: {
     fontFamily: typography.sans.regular.default,
-    fontWeight: '600',
   },
   LabelText: {
     fontFamily: typography.sans.bebas.default,
-    fontWeight: '700',
   },
 
   // UI-Kit
@@ -191,4 +183,11 @@ const overrides = {
 //   ...propOverrides,
 // };
 
-export default { colors, overrides, type, barStyle, buttons };
+export default {
+  colors,
+  type,
+  barStyle,
+  typography,
+  buttons,
+  overrides,
+};

--- a/ThePorch/src/theme/theme.js
+++ b/ThePorch/src/theme/theme.js
@@ -116,15 +116,19 @@ const overrides = {
   },
   H3: {
     fontFamily: typography.sans.regular.default,
+    fontWeight: '600',
   },
   H4: {
     fontFamily: typography.sans.regular.default,
+    fontWeight: '600',
   },
   H5: {
     fontFamily: typography.sans.regular.default,
+    fontWeight: '600',
   },
   H6: {
     fontFamily: typography.sans.regular.default,
+    fontWeight: '600',
   },
   LabelText: {
     fontFamily: typography.sans.bebas.default,


### PR DESCRIPTION
Match Android font to iOS by removing font-weight so there is consistency in the app across different devices. 

[Basecamp ](https://3.basecamp.com/3926363/buckets/16548009/todos/2713686350)

|iOS|Android|
|---|---|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-29 at 15 37 16](https://user-images.githubusercontent.com/52924611/86048392-73a1f300-ba1e-11ea-847b-a369df6f0b74.png)|![Screenshot_1593459450](https://user-images.githubusercontent.com/52924611/86048397-76044d00-ba1e-11ea-9956-fcc3ceb96948.png)|