### PR TITLE
Add margin bottom to themed tab bar

### DIFF
--- a/ThePorch/src/tabs/tabBar.js
+++ b/ThePorch/src/tabs/tabBar.js
@@ -15,6 +15,7 @@ const ThemedBottomTabBar = compose(
     borderTopWidth: 0,
     backgroundColor: theme.colors.background.paper,
     marginTop: theme.sizing.baseUnit * 0.3125,
+    marginBottom: theme.sizing.baseUnit * 0.3125,
   })),
   withTabBarMediaSpacer
 )(BottomTabBar);

--- a/ThePorch/src/tabs/tabBar.js
+++ b/ThePorch/src/tabs/tabBar.js
@@ -1,4 +1,5 @@
 import { compose } from 'recompose';
+import { Platform } from 'react-native';
 import { BottomTabBar } from 'react-navigation';
 
 import { withTabBarMediaSpacer } from '@apollosproject/ui-media-player';
@@ -15,7 +16,7 @@ const ThemedBottomTabBar = compose(
     borderTopWidth: 0,
     backgroundColor: theme.colors.background.paper,
     marginTop: theme.sizing.baseUnit * 0.3125,
-    marginBottom: theme.sizing.baseUnit * 0.3125,
+    ...(Platform.OS === 'android' ? { marginBottom: theme.sizing.baseUnit * 0.3125 } : {}),
   })),
   withTabBarMediaSpacer
 )(BottomTabBar);


### PR DESCRIPTION
This PR adds a bottom margin to the tab bar on Android devices.

|Before|After|
|---|---|
|![Screenshot_1604091492](https://user-images.githubusercontent.com/52924611/97756946-27e97e00-1ad2-11eb-92a7-10755f1b2eda.png)|![Screenshot_1604091443](https://user-images.githubusercontent.com/52924611/97756873-038da180-1ad2-11eb-8107-c6491e80d29d.png)|