### PR TITLE
Fix for querying speakers w/o ID

### DIFF
--- a/ThePorch/src/content-single/ConferenceContentItem/Speakers.js
+++ b/ThePorch/src/content-single/ConferenceContentItem/Speakers.js
@@ -57,6 +57,11 @@ class Speakers extends PureComponent {
 
   render() {
     const { contentId } = this.props;
+
+    if (!contentId) {
+      return null;
+    }
+
     return (
       <Query
         query={query}


### PR DESCRIPTION
* Changes Speakers.js to not issue query without ID

refs https://github.com/watermarkchurch/theporch-apollos/issues/151
