### PR TITLE
Remove unnecessary extra query to media system

### DIFF
--- a/ThePorch/loadConfig.js
+++ b/ThePorch/loadConfig.js
@@ -113,10 +113,6 @@ ApollosConfig.loadJs({
               uri
             }
           }
-          parentChannel {
-            id
-            name
-          }
           series {
             coverImage {
               sources {
@@ -153,10 +149,6 @@ ApollosConfig.loadJs({
             sources {
               uri
             }
-          }
-          parentChannel {
-            id
-            name
           }
           series {
             coverImage {


### PR DESCRIPTION
* Changes all the fragments to not unnecessarily cause an extra request to the root of the media system

refs https://github.com/watermarkchurch/theporch-apollos/issues/152