### PR TITLE
fix linked content item

### DIFF
--- a/apollos-church-api/src/data/contentful/Breakouts.js
+++ b/apollos-church-api/src/data/contentful/Breakouts.js
@@ -48,8 +48,10 @@ export const schema = gql`
 
 export const resolver = {
   Breakouts: {
-    id: ({ sys }, args, context, { parentType }) =>
-      createGlobalId(sys.id, parentType.name),
+    id: (entry, args, context, { parentType }) => {
+      const id = entry && (entry.sys && entry.sys.id || entry.id)
+      return createGlobalId(id, parentType.name)
+    },
     title: ({ fields }) => fields.title,
     summary: (node, args, { dataSources }) =>
       dataSources.ContentfulContentItem.createSummary(node),

--- a/apollos-church-api/src/data/contentful/Event.js
+++ b/apollos-church-api/src/data/contentful/Event.js
@@ -42,8 +42,10 @@ export const schema = gql`
 
 export const resolver = {
   Event: {
-    id: ({ sys }, args, context, { parentType }) =>
-      createGlobalId(sys.id, parentType.name),
+    id: (entry, args, context, { parentType }) => {
+      const id = entry && (entry.sys && entry.sys.id || entry.id)
+      return createGlobalId(id, parentType.name)
+    },
     title: ({ fields }) => fields.title,
     summary: (node, args, { dataSources }) =>
       dataSources.ContentfulContentItem.createSummary(node),


### PR DESCRIPTION
  Somehow the "entry" there did not have "sys" - it was a GQL node not a
  Contentful entry.

  This fixes the ID resolver to handle both when it's an entry or a
  node.